### PR TITLE
Restructure lua

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.lua]
+indent_style = space
+indent_size = 4

--- a/lua/go-up/init.lua
+++ b/lua/go-up/init.lua
@@ -52,18 +52,15 @@ end
 
 -- main setup function for Go-Up.nvim
 M.setup = function(opts)
-    opts = vim.tbl_deep_extend("keep", opts or {}, options.defaultOptions)
+    M.opts = vim.tbl_deep_extend("keep", opts or {}, options.defaultOptions)
 
-    options.validateOptions(opts)
-
-    -- share options
-    M.opts = opts
+    options.validateOptions(M.opts)
 
     -- modify settings
     modifySettings()
 
     autocmd_setup()
-    if internals.opts.mapZZ then
+    if M.opts.mapZZ then
       keymaps_setup()
     end
     usercmds_setup()

--- a/lua/go-up/init.lua
+++ b/lua/go-up/init.lua
@@ -1,47 +1,80 @@
-local goUpInternals = require('go-up.internals')
+local internals = require('go-up.internals')
 local options = require('go-up.options')
 
-local goUpModule = {}
+local M = {}
+
+
+local function autocmd_setup()
+    -- every time the text changes, make sure the virtual lines are not in the
+    -- middle of the text
+    local events = { 'BufEnter', 'TextChanged', 'TextChangedI' }
+    vim.api.nvim_create_autocmd(events, {
+        callback = internals.redraw,
+        group = vim.api.nvim_create_augroup('go-up', {}),
+        desc = 'go-up: redraw virtual toplines',
+    })
+end
+
+
+local function keymaps_setup()
+      -- adjust the scroll result when using zz to center the screen
+      vim.keymap.set('n', 'zz', internals.centerScreen, {
+        desc = 'go-up: center screen'
+      })
+end
+
+local function usercmds_setup()
+    vim.api.nvim_create_user_command('GoUpReset', internals.redraw, {
+        desc = 'Go-Up reset function'
+    })
+
+    vim.api.nvim_create_user_command('GoUpAlignTop', internals.alignTop, {
+        desc = 'Go-Up align top function'
+    })
+
+    vim.api.nvim_create_user_command('GoUpAlignBottom', internals.alignBottom, {
+        desc = 'Go-Up align bottom function'
+    })
+
+    vim.api.nvim_create_user_command('GoUpAlign', internals.align, {
+        desc = 'Go-Up align function'
+    })
+end
+
+local function modifySettings()
+    if not M.opts.respectSplitkeep then
+        vim.opt.splitkeep = 'topline'
+    end
+    if not M.opts.respectScrolloff then
+        vim.opt.scrolloff = 0
+    end
+end
 
 -- main setup function for Go-Up.nvim
-goUpModule.setup = function(opts)
-    -- make sure options is not nil
-    opts = opts or {}
+M.setup = function(opts)
+    opts = vim.tbl_deep_extend("keep", opts or {}, options.defaultOptions)
 
-    -- set default options if not already set
-    if opts.mapZZ == nil then
-        opts.mapZZ = options.defaultOptions.mapZZ
-    end
-    if opts.respectSplitkeep == nil then
-        opts.respectSplitkeep = options.defaultOptions.respectSplitkeep
-    end
-    if opts.respectScrolloff == nil then
-        opts.respectScrolloff = options.defaultOptions.respectScrolloff
-    end
-
-    -- validate options
     options.validateOptions(opts)
 
-    -- set options
-    goUpInternals.opts = opts
-    goUpModule.opts = opts
+    -- share options
+    M.opts = opts
 
     -- modify settings
-    goUpInternals.modifySettings()
+    modifySettings()
 
-    -- set up autocommands
-    goUpInternals.setUpAutocommands()
-
-    -- set up keymaps
-    goUpInternals.setUpKeymaps()
+    autocmd_setup()
+    if internals.opts.mapZZ then
+      keymaps_setup()
+    end
+    usercmds_setup()
 end
 
 -- public functions
-goUpModule.centerScreen = goUpInternals.centerScreen
-goUpModule.reset = goUpInternals.reset
-goUpModule.alignTop = goUpInternals.alignTop
-goUpModule.alignBottom = goUpInternals.alignBottom
-goUpModule.align = goUpInternals.align
+M.centerScreen = internals.centerScreen
+M.reset = internals.redraw
+M.alignTop = internals.alignTop
+M.alignBottom = internals.alignBottom
+M.align = internals.align
 
 -- export module
-return goUpModule
+return M

--- a/lua/go-up/internals.lua
+++ b/lua/go-up/internals.lua
@@ -3,29 +3,23 @@ local goUpInternals = {}
 -- create a namespace for the extmarks for the virtual lines
 goUpInternals.goUpNamespace = vim.api.nvim_create_namespace('Go-UpNamespace')
 
--- this function adds the extmarks to the current buffer
-local setUpExtmarks = function()
-    for line = 1, 100 do
-        vim.api.nvim_buf_set_extmark(0, goUpInternals.goUpNamespace, 0, 0, {
-            id = line,
-            virt_lines = { { { '', 'NonText' } } },
-            virt_lines_above = true,
-        })
-    end
-end
-
-goUpInternals.reset = function()
-    -- clear all extmarks in the namespace for the current buffer
+goUpInternals.redraw = function()
     vim.api.nvim_buf_clear_namespace(0, goUpInternals.goUpNamespace, 0, -1)
-    -- reset the extmarks
-    setUpExtmarks()
+
+    -- loop makes every line a single extmark and not one big block
+    for _ = 1, vim.api.nvim_win_get_height(0) do
+      vim.api.nvim_buf_set_extmark(0, goUpInternals.goUpNamespace, 0, 0, {
+        virt_lines = { { { '', 'NonText' } } },
+        virt_lines_above = true,
+      })
+    end
 end
 
 goUpInternals.setUpAutocommands = function()
     -- every time a buffer is entered, make sure the extmarks are set up
     vim.api.nvim_create_autocmd('BufEnter', {
         callback = function()
-            goUpInternals.reset()
+            goUpInternals.redraw()
         end,
         desc = 'set up extmarks for go-up',
     })
@@ -33,7 +27,7 @@ goUpInternals.setUpAutocommands = function()
     -- middle of the text
     vim.api.nvim_create_autocmd({ 'TextChanged', 'TextChangedI' }, {
         callback = function()
-            goUpInternals.reset()
+            goUpInternals.redraw()
         end,
     })
 end
@@ -129,7 +123,7 @@ goUpInternals.modifySettings = function()
 end
 
 vim.api.nvim_create_user_command('GoUpReset', function()
-    goUpInternals.reset()
+    goUpInternals.redraw()
 end, { desc = 'Go-Up reset function' })
 
 vim.api.nvim_create_user_command('GoUpAlignTop', function()

--- a/lua/go-up/internals.lua
+++ b/lua/go-up/internals.lua
@@ -8,10 +8,10 @@ M.redraw = function()
 
     -- loop makes every line a single extmark and not one big block
     for _ = 1, vim.api.nvim_win_get_height(0) do
-      vim.api.nvim_buf_set_extmark(0, ns, 0, 0, {
-        virt_lines = { { { '', 'NonText' } } },
-        virt_lines_above = true,
-      })
+        vim.api.nvim_buf_set_extmark(0, ns, 0, 0, {
+            virt_lines = { { { '', 'NonText' } } },
+            virt_lines_above = true,
+        })
     end
 end
 


### PR DESCRIPTION
Hi! I saw this plugin on reddit, thanks for it! It's really nice. I thought about including a very minimal version of this in my own config, but then I figured I could also contribute to this plugin. I currently did the following (in different commits, so you could cherrypick the ones you want to include):

- Dynamic number of virtual lines (fixes #2). Also renamed `reset()` to `redraw()`, as I thought that would be more fitting. The user-faced `require('go-up').reset()` and `:GoUpReset` are *not* renamed yet. Lmk what you want.
- Moved all setup functions (for keymaps, autocmds, usercmds) to init.lua. Now, init.lua handles all setup and internals.lua the actual functionality of the plugin.
- Added augroup to autocmds

I would also like the following:
- This plugin should not set a user's options. If `RespectScrollOff` is not set, then just use the `vim.o.scrolloff` version in the calculation to account for this.
- Vim has many ways of exporting your plugins functionality: `<Plug>GoUpXXX`, `require('go-up').XXX`, `:GoUpXXX`. Choose one that fits the users way of interacting the best:
  - <Plug>-keymapping: most probable that it will be a keymapping
  - Usercmd: Not used enough for a keymapping, but should be available on the fly
  - Lua: will be used programmatically, e.g. in other Lua functions
  - I would probably go with `<Plug>` mappings, but usercommands are also fine. You could then choose to define them as subcommands (i.e. `:GoUp alignBottom`) to not increase the amount of user commands as much
- What's the difference between `:GoUpAlignBottom` and normal mode `zb`?