### PR TITLE
feat: add ignoredFiletypes option to disable plugin for specific file…

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Go-Up provides the following functions that you can use.
     goUpLimit = nil,
     -- number of offset lines to use when aligning
     alignOffsetLines = { top = 0, bottom = 0 },
+    -- list of filetypes to ignore (e.g., 'neo-tree', 'NvimTree')
+    ignoredFiletypes = {},
 }
 ```
 
@@ -104,6 +106,7 @@ Go-Up provides the following functions that you can use.
 | `respectScrolloff`        | boolean                     | `false` | Go-Up works best when `scrolloff` is set to `0`[<sup>[ref]</sup>](https://github.com/nullromo/go-up.nvim/issues/3), so it does that by default. Set `respectScrolloff` to `true` to prevent Go-Up from modifying `scrolloff`.                                                                                                                                                       |
 | `respectSplitkeep`        | boolean                     | `false` | Go-Up works best when `splitkeep` is set to `'topline'`[<sup>[ref]</sup>](https://github.com/nullromo/go-up.nvim/issues/4), so it does that by default. Set `respectSplitkeep` to `true` to prevent Go-Up from modifying `splitkeep`.                                                                                                                                               |
 | `respectSmoothscroll`     | boolean                     | `false` | Go-Up works best when `smoothscroll` is enabled[<sup>[ref]</sup>](https://github.com/nullromo/go-up.nvim/pull/16), so it enables this by default. Set `respectSmoothscroll` to `true` to prevent Go-Up from modifying `smoothscroll`.                                                                                                                                               |
+| `ignoredFiletypes`        | string[]                    | `{}`    | List of filetypes where Go-Up should be disabled. Useful for plugins like `neo-tree` or `NvimTree` where virtual lines would interfere with the UI. Ignored even when running user commands directly. Example: `ignoredFiletypes = { 'neo-tree', 'NvimTree', 'Trouble' }`                                                                                                                                                             |
 | `goUpLimit`               | nil or number or `'center'` | `nil`   | By default, Go-Up will allow you to scroll up until line 1 of your buffer hits the bottom of your window. This can be limited to a number of lines, or set to `'center'` to only allow scrolling until line 1 is centered in the window.                                                                                                                                            |
 | `alignOffsetLines.top`    | number                      | `0`     | The Go-Up align functions will scroll until this many of the virtual lines are still in view. Some other plugins may insert virtual lines to display various GUI elements[<sup>[ref]</sup>](https://github.com/nullromo/go-up.nvim/issues/5), causing the align functions to misalign. This option can help overcome the resulting incompatibility by modifying the align behavior. |
 | `alignOffsetLines.bottom` | number                      | `0`     | See `alignOffsetLines.top`.                                                                                                                                                                                                                                                                                                                                                         |
@@ -140,7 +143,7 @@ I am very open to feedback and criticism.
 
 -   🥉 [collindutter](https://github.com/collindutter)
 -   🏅
-    [`<Your name here>`](https://github.com/nullromo/go-up.nvim/blob/main/README.md#-donating)
+  [`<Your name here>`](https://github.com/nullromo/go-up.nvim/blob/main/README.md#-donating)
 
 ## ⏫ Donating
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Go-Up provides the following functions that you can use.
     goUpLimit = nil,
     -- number of offset lines to use when aligning
     alignOffsetLines = { top = 0, bottom = 0 },
-    -- list of filetypes to ignore (e.g., 'neo-tree', 'NvimTree')
+    -- list of filetypes to ignore
     ignoredFiletypes = {},
 }
 ```
@@ -106,7 +106,7 @@ Go-Up provides the following functions that you can use.
 | `respectScrolloff`        | boolean                     | `false` | Go-Up works best when `scrolloff` is set to `0`[<sup>[ref]</sup>](https://github.com/nullromo/go-up.nvim/issues/3), so it does that by default. Set `respectScrolloff` to `true` to prevent Go-Up from modifying `scrolloff`.                                                                                                                                                       |
 | `respectSplitkeep`        | boolean                     | `false` | Go-Up works best when `splitkeep` is set to `'topline'`[<sup>[ref]</sup>](https://github.com/nullromo/go-up.nvim/issues/4), so it does that by default. Set `respectSplitkeep` to `true` to prevent Go-Up from modifying `splitkeep`.                                                                                                                                               |
 | `respectSmoothscroll`     | boolean                     | `false` | Go-Up works best when `smoothscroll` is enabled[<sup>[ref]</sup>](https://github.com/nullromo/go-up.nvim/pull/16), so it enables this by default. Set `respectSmoothscroll` to `true` to prevent Go-Up from modifying `smoothscroll`.                                                                                                                                               |
-| `ignoredFiletypes`        | string[]                    | `{}`    | List of filetypes where Go-Up should be disabled. Useful for plugins like `neo-tree` or `NvimTree` where virtual lines would interfere with the UI. Ignored even when running user commands directly. Example: `ignoredFiletypes = { 'neo-tree', 'NvimTree', 'Trouble' }`                                                                                                                                                             |
+| `ignoredFiletypes`        | string[]                    | `{}`    | List of filetypes where Go-Up should be disabled. Useful for plugins where virtual lines would interfere with the UI. Files of the specified types are ignored even when running user commands directly. Example: `ignoredFiletypes = { 'neo-tree', 'NvimTree', 'Trouble' }`.                                                                                                       |
 | `goUpLimit`               | nil or number or `'center'` | `nil`   | By default, Go-Up will allow you to scroll up until line 1 of your buffer hits the bottom of your window. This can be limited to a number of lines, or set to `'center'` to only allow scrolling until line 1 is centered in the window.                                                                                                                                            |
 | `alignOffsetLines.top`    | number                      | `0`     | The Go-Up align functions will scroll until this many of the virtual lines are still in view. Some other plugins may insert virtual lines to display various GUI elements[<sup>[ref]</sup>](https://github.com/nullromo/go-up.nvim/issues/5), causing the align functions to misalign. This option can help overcome the resulting incompatibility by modifying the align behavior. |
 | `alignOffsetLines.bottom` | number                      | `0`     | See `alignOffsetLines.top`.                                                                                                                                                                                                                                                                                                                                                         |
@@ -141,8 +141,8 @@ I am very open to feedback and criticism.
 
 ### Bronze Tier Sponsors
 
--   🥉 [collindutter](https://github.com/collindutter)
--   🏅
+- 🥉 [collindutter](https://github.com/collindutter)
+- 🏅
   [`<Your name here>`](https://github.com/nullromo/go-up.nvim/blob/main/README.md#-donating)
 
 ## ⏫ Donating

--- a/lua/go-up/internals.lua
+++ b/lua/go-up/internals.lua
@@ -5,9 +5,20 @@ local M = {}
 -- create a namespace for the extmarks for the virtual lines
 local goUpNamespace = vim.api.nvim_create_namespace('go-up')
 
+-- Check if the current buffer should be ignored based on filetype
+M.shouldIgnoreBuffer = function()
+    local ft = vim.bo.filetype or ''
+    local ignored = options.opts.ignoredFiletypes or {}
+    return #ignored > 0 and vim.tbl_contains(ignored, ft)
+end
+
 M.redraw = function()
     -- clear all existing extmarks
     vim.api.nvim_buf_clear_namespace(0, goUpNamespace, 0, -1)
+
+    if M.shouldIgnoreBuffer() then
+        return
+    end
 
     -- compute how many virtual lines to add
     local totalLines = (function()
@@ -34,6 +45,11 @@ end
 -- centers the screen normally, then adjusts so that the current line is
 -- actually centered
 M.centerScreen = function()
+    if M.shouldIgnoreBuffer() then
+        vim.cmd('normal! zz')
+        return
+    end
+
     -- center the screen first, then adjust
     vim.cmd('normal! zz')
 
@@ -63,6 +79,10 @@ end
 -- if the file is below the top of the window, scrolls down until line 1 is at
 -- the top
 M.alignTop = function()
+    if M.shouldIgnoreBuffer() then
+        return
+    end
+    
     local windowID = vim.fn.win_getid()
     local windowScreenPosition = vim.fn.win_screenpos(windowID)[1]
     local firstLineScreenPosition = vim.fn.screenpos(windowID, 1, 1).row
@@ -78,6 +98,10 @@ end
 -- if the last line of the file is above the bottom of the window, scrolls up
 -- until the last line is at the bottom
 M.alignBottom = function()
+    if M.shouldIgnoreBuffer() then
+        return
+    end
+    
     local windowID = vim.fn.win_getid()
     local windowScreenPosition = vim.fn.win_screenpos(windowID)[1]
     local windowHeight = vim.fn.getwininfo(windowID)[1].height
@@ -96,6 +120,10 @@ M.alignBottom = function()
 end
 
 M.align = function()
+    if M.shouldIgnoreBuffer() then
+        return
+    end
+    
     local windowID = vim.fn.win_getid()
     local lastLineNumber = vim.fn.line('$', windowID)
     local firstLineScreenPosition = vim.fn.screenpos(windowID, 1, 1).row

--- a/lua/go-up/internals.lua
+++ b/lua/go-up/internals.lua
@@ -82,7 +82,7 @@ M.alignTop = function()
     if M.shouldIgnoreBuffer() then
         return
     end
-    
+
     local windowID = vim.fn.win_getid()
     local windowScreenPosition = vim.fn.win_screenpos(windowID)[1]
     local firstLineScreenPosition = vim.fn.screenpos(windowID, 1, 1).row
@@ -101,7 +101,7 @@ M.alignBottom = function()
     if M.shouldIgnoreBuffer() then
         return
     end
-    
+
     local windowID = vim.fn.win_getid()
     local windowScreenPosition = vim.fn.win_screenpos(windowID)[1]
     local windowHeight = vim.fn.getwininfo(windowID)[1].height
@@ -123,7 +123,7 @@ M.align = function()
     if M.shouldIgnoreBuffer() then
         return
     end
-    
+
     local windowID = vim.fn.win_getid()
     local lastLineNumber = vim.fn.line('$', windowID)
     local firstLineScreenPosition = vim.fn.screenpos(windowID, 1, 1).row

--- a/lua/go-up/internals.lua
+++ b/lua/go-up/internals.lua
@@ -5,11 +5,10 @@ local M = {}
 -- create a namespace for the extmarks for the virtual lines
 local goUpNamespace = vim.api.nvim_create_namespace('go-up')
 
-    local ft = vim.bo.filetype or ''
 -- check if the current buffer should be ignored based on filetype
 local shouldIgnoreBuffer = function()
     local ignored = options.opts.ignoredFiletypes or {}
-    return #ignored > 0 and vim.tbl_contains(ignored, ft)
+    return #ignored > 0 and vim.tbl_contains(ignored, vim.bo.filetype or '')
 end
 
 M.redraw = function()
@@ -45,13 +44,12 @@ end
 -- centers the screen normally, then adjusts so that the current line is
 -- actually centered
 M.centerScreen = function()
-    if shouldIgnoreBuffer() then
-        vim.cmd('normal! zz')
-        return
-    end
-
     -- center the screen first, then adjust
     vim.cmd('normal! zz')
+
+    if shouldIgnoreBuffer() then
+        return
+    end
 
     -- get the line the cursor is on
     local currentLine = vim.fn.winline()

--- a/lua/go-up/internals.lua
+++ b/lua/go-up/internals.lua
@@ -5,9 +5,9 @@ local M = {}
 -- create a namespace for the extmarks for the virtual lines
 local goUpNamespace = vim.api.nvim_create_namespace('go-up')
 
--- Check if the current buffer should be ignored based on filetype
-M.shouldIgnoreBuffer = function()
     local ft = vim.bo.filetype or ''
+-- check if the current buffer should be ignored based on filetype
+local shouldIgnoreBuffer = function()
     local ignored = options.opts.ignoredFiletypes or {}
     return #ignored > 0 and vim.tbl_contains(ignored, ft)
 end
@@ -16,7 +16,7 @@ M.redraw = function()
     -- clear all existing extmarks
     vim.api.nvim_buf_clear_namespace(0, goUpNamespace, 0, -1)
 
-    if M.shouldIgnoreBuffer() then
+    if shouldIgnoreBuffer() then
         return
     end
 
@@ -45,7 +45,7 @@ end
 -- centers the screen normally, then adjusts so that the current line is
 -- actually centered
 M.centerScreen = function()
-    if M.shouldIgnoreBuffer() then
+    if shouldIgnoreBuffer() then
         vim.cmd('normal! zz')
         return
     end
@@ -79,7 +79,7 @@ end
 -- if the file is below the top of the window, scrolls down until line 1 is at
 -- the top
 M.alignTop = function()
-    if M.shouldIgnoreBuffer() then
+    if shouldIgnoreBuffer() then
         return
     end
 
@@ -98,7 +98,7 @@ end
 -- if the last line of the file is above the bottom of the window, scrolls up
 -- until the last line is at the bottom
 M.alignBottom = function()
-    if M.shouldIgnoreBuffer() then
+    if shouldIgnoreBuffer() then
         return
     end
 
@@ -120,7 +120,7 @@ M.alignBottom = function()
 end
 
 M.align = function()
-    if M.shouldIgnoreBuffer() then
+    if shouldIgnoreBuffer() then
         return
     end
 

--- a/lua/go-up/options.lua
+++ b/lua/go-up/options.lua
@@ -19,6 +19,8 @@ options.defaultOptions = {
     goUpLimit = nil,
     -- number of offset lines to use when aligning
     alignOffsetLines = { top = 0, bottom = 0 },
+    -- list of filetypes to ignore
+    ignoredFiletypes = {},
 }
 
 options.validateOptions = function(opts)
@@ -40,6 +42,15 @@ options.validateOptions = function(opts)
                 error(
                     'goUpLimit must be nil, a number, or "center" for Go-Up.nvim'
                 )
+            end
+        elseif key == 'ignoredFiletypes' then
+            if type(value) ~= 'table' then
+                error('opts.ignoredFiletypes must be a table for Go-Up.nvim')
+            end
+            for _, ft in ipairs(value) do
+                if type(ft) ~= 'string' then
+                    error('all items in opts.ignoredFiletypes must be strings')
+                end
             end
         elseif key == 'alignOffsetLines' then
             for key2, value2 in pairs(value) do

--- a/lua/go-up/options.lua
+++ b/lua/go-up/options.lua
@@ -49,7 +49,9 @@ options.validateOptions = function(opts)
             end
             for _, ft in ipairs(value) do
                 if type(ft) ~= 'string' then
-                    error('all items in opts.ignoredFiletypes must be strings')
+                    error(
+                        'all items in opts.ignoredFiletypes must be strings for Go-Up.nvim'
+                    )
                 end
             end
         elseif key == 'alignOffsetLines' then


### PR DESCRIPTION
centering on neo-tree windows was kinda annoying so thought id take issue #15 on. im not an expert on neovim api and lua so this is a draft and would love if you could review it first. especially the handling of user opts like on internals.lua shouldIgnoreBuffer()

i currently put the ignore buffer checks inside the M. functions which ignores the buffers all the time even if the user calls the user command directly. i considered putting the checks as a seperate flag in the user command but really couldnt think of a use case for that. that and its simplier this way.

on my end it seems to work just fine on 'neo-tree' and 'lua' filetypes as a test. let me know if anything iffy stands out to you though!